### PR TITLE
fix: allow restricting certain member access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datawrapper/expr-eval",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datawrapper/expr-eval",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "devDependencies": {
         "eslint": "^6.3.0",
         "eslint-config-semistandard": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datawrapper/expr-eval",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Mathematical expression evaluator",
   "main": "dist/bundle.js",
   "module": "dist/index.mjs",

--- a/src/parser-state.js
+++ b/src/parser-state.js
@@ -11,6 +11,7 @@ export function ParserState(parser, tokenStream, options) {
   this.savedCurrent = null;
   this.savedNextToken = null;
   this.allowMemberAccess = options.allowMemberAccess !== false;
+  this.preventMemberAccess = new Set(options.preventMemberAccess || []);
 }
 
 ParserState.prototype.next = function () {
@@ -316,6 +317,9 @@ ParserState.prototype.parseMemberExpression = function (instr) {
     if (op.value === '.') {
       if (!this.allowMemberAccess) {
         throw new Error('unexpected ".", member access is not permitted');
+      }
+      if (this.restrictMemberAccess.has(this.nextToken.value)) {
+        throw new Error('access to member "'+this.nextToken.value+'" is not permitted');
       }
 
       this.expect(TNAME);

--- a/src/parser.js
+++ b/src/parser.js
@@ -146,7 +146,8 @@ export function Parser(options) {
 Parser.prototype.parse = function (expr) {
   var instr = [];
   var parserState = new ParserState(this, new TokenStream(this, expr), {
-    allowMemberAccess: this.options.allowMemberAccess
+    allowMemberAccess: this.options.allowMemberAccess,
+    restrictMemberAccess: this.options.restrictMemberAccess
   });
 
   parserState.parseExpression(instr);

--- a/test/parser.js
+++ b/test/parser.js
@@ -595,4 +595,12 @@ describe('Parser', function () {
     assert.throws(function () { parser.evaluate('32 + min.bind'); }, /member access is not permitted/);
     assert.throws(function () { parser.evaluate('a.b', { a: { b: 2 } }); }, /member access is not permitted/);
   });
+  
+  it('should restrict certain member access', function () {
+    var parser = new Parser({ allowMemberAccess: true, restrictMemberAccess: ['b', 'constructor', '__proto__'] });
+    assert.throws(function () { parser.evaluate('a.b', { a: { b: 2, c: 3 } }); }, /access to member "b" is not permitted/);
+    assert.throws(function () { parser.evaluate('min.__proto__'); }, /access to member "__proto__" is not permitted/);
+    assert.throws(function () { parser.evaluate('min.constructor'); }, /access to member "constructor" is not permitted/);
+    assert.doesNotThrow(function () { parser.evaluate('a.c', { a: { b: 2, c: 3 } }); });
+  });
 });


### PR DESCRIPTION
This adds a new Parser option `restrictMemberAccess` which can be used to prevent certain member properties to be accessed throw the `.` operator.

```js
it('should restrict certain member access', function () {
    var parser = new Parser({ allowMemberAccess: true, restrictMemberAccess: ['b', 'constructor', '__proto__'] });
    assert.throws(function () { parser.evaluate('a.b', { a: { b: 2, c: 3 } }); }, /access to member "b" is not permitted/);
    assert.throws(function () { parser.evaluate('min.__proto__'); }, /access to member "__proto__" is not permitted/);
    assert.throws(function () { parser.evaluate('min.constructor'); }, /access to member "constructor" is not permitted/);
    assert.doesNotThrow(function () { parser.evaluate('a.c', { a: { b: 2, c: 3 } }); });
  });
```